### PR TITLE
Detect degraded MegaRAID arrays

### DIFF
--- a/bin/check-raid.rb
+++ b/bin/check-raid.rb
@@ -109,9 +109,10 @@ class CheckRaid < Sensu::Plugin::Check::CLI
     # #YELLOW
     if File.exist?('/usr/sbin/megacli') # rubocop:disable GuardClause
       contents = `/usr/sbin/megacli -AdpAllInfo -aALL`
-      c = contents.lines.grep(/(Critical|Failed) Disks\s+\: 0/)
+      failed = contents.lines.grep(/(Critical|Failed) Disks\s+\: 0/)
+      degraded = contents.lines.grep(/Degraded\s+\: 0/)
       # #YELLOW
-      unless c.empty? # rubocop:disable UnlessElse
+      unless failed.empty? or degraded.empty? # rubocop:disable UnlessElse
         ok 'MegaRaid RAID OK'
       else
         warning 'MegaRaid RAID warning'

--- a/bin/check-raid.rb
+++ b/bin/check-raid.rb
@@ -112,7 +112,7 @@ class CheckRaid < Sensu::Plugin::Check::CLI
       failed = contents.lines.grep(/(Critical|Failed) Disks\s+\: 0/)
       degraded = contents.lines.grep(/Degraded\s+\: 0/)
       # #YELLOW
-      unless failed.empty? or degraded.empty? # rubocop:disable UnlessElse
+      unless failed.empty? || degraded.empty? # rubocop:disable UnlessElse
         ok 'MegaRaid RAID OK'
       else
         warning 'MegaRaid RAID warning'


### PR DESCRIPTION
I think the check for MegaRAID controllers should also detect degraded arrays (besides critical and failed disks). This pull request implements such a check, based on the existing output of `megacli -AdpAllInfo -aALL`.
