### PR TITLE
improve software raid check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [0.1.1] - 2016-09-01
+### Added
+- improvement to regex checks for check_software method in check-raid plugin
+
 ## [0.1.0] - 2015-09-14
 ### Added
 - added a new check-mpt2sas-status plugin
@@ -32,7 +36,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[unreleased]: https://github.com/sensu-plugins/sensu-plugins-raid-checks/compare/0.1.0...HEAD
+[unreleased]: https://github.com/sensu-plugins/sensu-plugins-raid-checks/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/sensu-plugins/sensu-plugins-raid-checks/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/sensu-plugins/sensu-plugins-raid-checks/compare/0.0.4...0.1.0
 [0.0.4]: https://github.com/sensu-plugins/sensu-plugins-raid-checks/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/sensu-plugins/sensu-plugins-raid-checks/compare/0.0.2...0.0.3

--- a/bin/check-raid.rb
+++ b/bin/check-raid.rb
@@ -35,9 +35,9 @@ class CheckRaid < Sensu::Plugin::Check::CLI
   def check_software
     if File.exist?('/proc/mdstat')
       contents = File.read('/proc/mdstat')
-      mg = contents.lines.grep(/active/)
+      mg = contents.lines.grep(/active|blocks/)
       unless mg.empty?
-        sg = mg.to_s.lines.grep(/\]\(F\)/)
+        sg = mg.to_s.lines.grep(/\]\(F\)|[\[U]_/)
         unless sg.empty? # rubocop:disable UnlessElse
           warning 'Software RAID warning'
         else


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
no
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
#### Purpose

The current software raid check only looks for failed devices (see example 6)[1]. This commit modifies the regex to look for and warn on degraded arrays (see examples 2 and 4)[1] in addition to failed devices.

[1] https://raid.wiki.kernel.org/index.php/Mdstat
