### PR TITLE
Add option to specify tw-cli binary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- add option to check-3ware-status to specify the path to tw-cli binary
 
 ## [0.1.1] - 2016-09-01
 ### Added

--- a/bin/check-3ware-status.rb
+++ b/bin/check-3ware-status.rb
@@ -24,7 +24,7 @@
 #
 #   tw-cli requires root permissions.
 #
-#   Create a file named /etc/sudoers.d/tw-cli with this line inside :
+#   Create a file named /etc/sudoers.d/tw-cli with the path to your tw-cli inside :
 #   sensu ALL=(ALL) NOPASSWD: /usr/sbin/tw-cli
 #
 # You can get Debian/Ubuntu tw-cli packages here - http://hwraid.le-vert.net/

--- a/bin/check-3ware-status.rb
+++ b/bin/check-3ware-status.rb
@@ -41,11 +41,17 @@ require 'open3'
 # Check 3ware Status
 #
 class Check3wareStatus < Sensu::Plugin::Check::CLI
+  option :twclicommand,
+         description: 'the tw-cli executable',
+         short: '-c CMD',
+         long: '--command CMD',
+         default: 'tw-cli'
+
   # Setup variables
   #
   def initialize
     super
-    @binary = 'sudo -n -k tw-cli'
+    @binary = "sudo -n -k #{config[:twclicommand]}"
     @controllers = []
     @good_disks = []
     @bad_disks = []


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Unfortunately there are no officially prepackaged version of `tw-cli` or `tw_cli`. This PR adds an option to specify the path to said binary.

#### Known Compatablity Issues
