### PR TITLE
adding ability to not create logfile via MegaCLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Change
+- `check-raid.rb`: added option `--log` with a default of `false` to prevent it default creating a log which is frequently being written to and filling up the disk. This does the *opposite* of what the vendor defaults are but due to the nature of those running it through a monitoring solution like sensu the defaults do not make sense in this use case. If you are wanting those logs you can change this to `true` to keep existing behavior.
+
 ### Added
 - Ruby 2.4.1 testing
 

--- a/bin/check-raid.rb
+++ b/bin/check-raid.rb
@@ -30,6 +30,12 @@ require 'sensu-plugin/check/cli'
 # Check Raid
 #
 class CheckRaid < Sensu::Plugin::Check::CLI
+  option :log,
+         description: 'Enables or disables logging for megacli',
+         short: '-l VALUE',
+         long: '--log VALUE',
+         boolean: true,
+         default: false
   # Check software raid
   #
   def check_software
@@ -103,7 +109,11 @@ class CheckRaid < Sensu::Plugin::Check::CLI
   #
   def check_mega_raid
     if File.exist?('/usr/sbin/megacli')
-      contents = `/usr/sbin/megacli -AdpAllInfo -aALL`
+      contents = if config[:log]
+                   `/usr/sbin/megacli -AdpAllInfo -aALL`
+                 else
+                   `/usr/sbin/megacli -AdpAllInfo -aALL -NoLog`
+                 end
       failed = contents.lines.grep(/(Critical|Failed) Disks\s+\: 0/)
       degraded = contents.lines.grep(/Degraded\s+\: 0/)
       # #YELLOW


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

added option --log with a default of false to prevent it default creating a log which is frequently being written to and filling up the disk

#### Known Compatibility Issues

This does the opposite of what the vendor defaults are but due to the nature of those running it through a monitoring solution like sensu the defaults do not make sense in this use case. If you are wanting those logs you can change this to true to keep existing behavior.

