### PR TITLE
Fix the broken check-megraid-sas-status script in 2.0.1

### DIFF
--- a/bin/check-megaraid-sas-status.rb
+++ b/bin/check-megaraid-sas-status.rb
@@ -58,7 +58,7 @@ class CheckMegaRAID < Sensu::Plugin::Check::CLI
     (0..$CHILD_STATUS.exitstatus - 1).each do |i|
       # and check them in turn
       stdout = `#{config[:megaraidcmd]} -LDInfo -L#{i} -a#{config[:controller]} `
-      unless Regexp.new('State\s*:\s*Optimal').match?(stdout)
+      unless Regexp.new('State\s*:\s*Optimal').match(stdout)
         error = sprintf '%svirtual drive %d: %s ', error, i, stdout[/State\s*:\s*.*/].split(':')[1] # rubocop:disable Style/FormatString
         have_error = true
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Recent version 2.0.1 has a syntax issue in check-megaraid-sas-status.

#### Known Compatibility Issues
