### PR TITLE
Fix software raid check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
 - fixed software raid check (@corro)
 
 ## [2.0.1] - 2017-01-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- fixed software raid check (@corro)
 
 ## [2.0.1] - 2017-01-31
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Changed
+### Fixed
 - fixed software raid check (@corro)
 
 ## [2.0.1] - 2017-01-31

--- a/bin/check-raid.rb
+++ b/bin/check-raid.rb
@@ -44,7 +44,7 @@ class CheckRaid < Sensu::Plugin::Check::CLI
     return unless File.exist?('/proc/mdstat')
     contents = File.read('/proc/mdstat')
     mg = contents.lines.grep(/active|blocks/)
-    return unless mg.empty?
+    return if mg.empty?
     sg = mg.to_s.lines.grep(/\]\(F\)|[\[U]_/)
     if sg.empty?
       ok 'Software RAID OK'


### PR DESCRIPTION
This PR fixes issue #19. I'm not too familiar with ruby development, therefore I don't know how to run RuboCop or the test suite. The change should be straightforward enough, though.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Fix bug indicating that software RAID is not present.

Output of `/proc/mdstat` (array `md1` degraded):
```
$ cat /proc/mdstat
Personalities : [raid1] [linear] [multipath] [raid0] [raid6] [raid5] [raid4] [raid10] 
md1 : active raid1 sdb3[2]
      976378688 blocks super 1.2 [2/1] [_U]
      
md0 : active raid1 sda2[0] sdb2[1]
      249664 blocks super 1.2 [2/2] [UU]
      
unused devices: <none>
```

Before:
```
$ /opt/sensu/embedded/bin/check-raid.rb 
CheckRaid OK: No RAID present
```

After:
```
$ /opt/sensu/embedded/bin/check-raid.rb
CheckRaid WARNING: Software RAID warning
```