### PR TITLE
Options to use `sudo` and specify path to MegaCli binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- add option to run binaries with `sudo`
 
 ## [2.0.3] - 2019-02-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 ### Added
 - add option to run binaries with `sudo`
+- add option to check-raid to specify the path to MegaCli binary
 
 ## [2.0.3] - 2019-02-17
 ### Fixed

--- a/bin/check-raid.rb
+++ b/bin/check-raid.rb
@@ -52,6 +52,12 @@ class CheckRaid < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :megacli,
+         description: 'the MegaCli executable',
+         short: '-m CMD',
+         long: '--megacli CMD',
+         default: '/usr/sbin/megacli'
+
   # Check software raid
   #
   def check_software_raid
@@ -120,11 +126,11 @@ class CheckRaid < Sensu::Plugin::Check::CLI
   # Check Megaraid
   #
   def check_mega_raid
-    return unless File.exist?('/usr/sbin/megacli')
+    return unless File.exist?(config[:megacli])
     contents = if config[:log]
-                 `#{@cmd_prefix}/usr/sbin/megacli -AdpAllInfo -aALL`
+                 `#{@cmd_prefix}#{config[:megacli]} -AdpAllInfo -aALL`
                else
-                 `#{@cmd_prefix}/usr/sbin/megacli -AdpAllInfo -aALL -NoLog`
+                 `#{@cmd_prefix}#{config[:megacli]} -AdpAllInfo -aALL -NoLog`
                end
     failed = contents.lines.grep(/(Critical|Failed) Disks\s+\: 0/)
     degraded = contents.lines.grep(/Degraded\s+\: 0/)


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
* Running the whole check with `sudo` may not be the optimal solution, so this PR adds an option to call specific commands and options with `sudo`.
* Option to specify path to the MegaCli binary is added, as it can be installed into different location depending on the packages used.
#### Known Compatibility Issues
